### PR TITLE
Fix Showroom heading typo in contact sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
             </div>
             <div class="phone">
               <div class="title flex">
-                <h2>Showromm</h2>
+                <h2>Showroom</h2>
                 <img src="assets/icons/location.svg" alt="Telefone" />
               </div>
               <p>

--- a/pages/about.html
+++ b/pages/about.html
@@ -310,7 +310,7 @@
             </div>
             <div class="phone">
               <div class="title flex">
-                <h2>Showromm</h2>
+                <h2>Showroom</h2>
                 <img src="../assets/icons/location.svg" alt="Telefone" />
               </div>
               <p>

--- a/pages/budget.html
+++ b/pages/budget.html
@@ -59,7 +59,7 @@
             </div>
             <div class="phone">
               <div class="title flex">
-                <h2>Showromm</h2>
+                <h2>Showroom</h2>
                 <img src="../assets/icons/location.svg" alt="Telefone" />
               </div>
               <p>


### PR DESCRIPTION
## Summary
- update the contact section heading text from "Showromm" to "Showroom" across the shared blocks

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_6908c8d23704832fa8b1c974fcca10d8