### PR TITLE
Clarify rename route production limitations

### DIFF
--- a/backend/routes/blocosRoutes.js
+++ b/backend/routes/blocosRoutes.js
@@ -98,7 +98,12 @@ router.delete("/delete", (req, res) => {
 });
 
 // ↓↓↓ Renomear pasta
-// Renomear pasta (modo local ou produção)
+// Observação: somente o fluxo local está funcional neste momento. O bloco de produção
+// depende de helpers do Drive (ex.: getDriveFolderId, listDriveFilesInFolder,
+// createFolder, moveFileOrFolder e do próprio client drive) que ainda não existem no
+// driveService.
+// TODO: disponibilizar essas funções no serviço do Drive e revisar o uso aqui antes de
+// ativar o fluxo em produção.
 router.put("/rename", async (req, res) => {
   const { path: currentPath, oldName, newName } = req.body;
 


### PR DESCRIPTION
## Summary
- update the rename route comment to clarify that only the local flow currently works
- add a TODO describing the missing Drive helpers needed for production support

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6908cb8fb344832fb28af7198cc4c5d8