### PR TITLE
Fix Prisma schema definition for ambientes

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -13,6 +13,7 @@ model CatalogItem {
   name      String
   type      String?
   material  String?
+  /// Lista de ambientes associados ao item.
   ambientes Json
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt


### PR DESCRIPTION
## Summary
- document the `ambientes` field in the Prisma schema to clarify its intended JSON usage

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_6908f0496ecc832fbd2c485a7d9ea05e