### PR TITLE
Add example environment configuration for backend

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,8 @@
+# Porta onde o servidor Express será executado
+PORT=3000
+
+# Caminho para o banco de dados SQLite utilizado pelo Prisma
+DATABASE_URL="file:backend/var/database.sqlite"
+
+# Diretório onde as imagens do catálogo serão salvas
+CATALOG_UPLOAD_DIR="assets/images/catalogo"

--- a/backend/README.md
+++ b/backend/README.md
@@ -92,7 +92,11 @@ As imagens são salvas em `assets/images/catalogo` com nomes normalizados (`nome
 | `DATABASE_URL`       | URL do banco SQLite usado pelo Prisma            | `file:backend/var/database.sqlite` |
 | `CATALOG_UPLOAD_DIR` | Diretório onde as imagens serão armazenadas      | `assets/images/catalogo`           |
 
-Crie um arquivo `.env` na pasta `backend` para personalizar os valores quando necessário.
+Copie o arquivo `.env.example` para `.env` na pasta `backend` e ajuste os valores conforme necessário:
+
+```bash
+cp .env.example .env
+```
 
 ## Testes
 


### PR DESCRIPTION
## Summary
- add a versioned `.env.example` file with default backend values
- update the backend README with instructions to copy the example to `.env`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6908f19bb818832f83288513dba14c6c