### PR TITLE
Handle ambientes serialization without Prisma JSON support

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -13,8 +13,8 @@ model CatalogItem {
   name      String
   type      String?
   material  String?
-  /// Lista de ambientes associados ao item.
-  ambientes Json
+  /// Lista de ambientes associados ao item (JSON serializado).
+  ambientes String
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 }

--- a/backend/prisma/seed.js
+++ b/backend/prisma/seed.js
@@ -1,7 +1,10 @@
 const fs = require("fs");
 const path = require("path");
 const { prisma } = require("../src/lib/prisma-client");
-const { normalizeAmbientes } = require("../src/utils/ambientes");
+const {
+  normalizeAmbientes,
+  serializeAmbientes,
+} = require("../src/utils/ambientes");
 
 async function seedCatalog() {
   const catalogPath = path.join(__dirname, "..", "..", "assets", "catalogo.json");
@@ -16,6 +19,7 @@ async function seedCatalog() {
 
   for (const item of items) {
     const ambientes = normalizeAmbientes(item.ambientes);
+    const storedAmbientes = serializeAmbientes(ambientes);
 
     await prisma.catalogItem.upsert({
       where: { image: item.imagem },
@@ -24,13 +28,13 @@ async function seedCatalog() {
         name: item.nome,
         type: item.tipo || null,
         material: item.material || null,
-        ambientes,
+        ambientes: storedAmbientes,
       },
       update: {
         name: item.nome,
         type: item.tipo || null,
         material: item.material || null,
-        ambientes,
+        ambientes: storedAmbientes,
       },
     });
   }

--- a/backend/src/repositories/catalog-repository.js
+++ b/backend/src/repositories/catalog-repository.js
@@ -1,5 +1,9 @@
 require("../config/register-alias");
 const { PrismaClientKnownRequestError } = require("@prisma/client/runtime/library");
+const {
+  serializeAmbientes,
+  parseStoredAmbientes,
+} = require("@/utils/ambientes");
 const { prisma } = require("@/lib/prisma-client");
 
 function mapCatalogItem(entity) {
@@ -13,7 +17,7 @@ function mapCatalogItem(entity) {
     nome: entity.name,
     tipo: entity.type,
     material: entity.material,
-    ambientes: entity.ambientes,
+    ambientes: parseStoredAmbientes(entity.ambientes),
     createdAt: entity.createdAt,
     updatedAt: entity.updatedAt,
   };
@@ -27,7 +31,7 @@ async function create(item) {
         name: item.nome,
         type: item.tipo,
         material: item.material,
-        ambientes: item.ambientes,
+        ambientes: serializeAmbientes(item.ambientes),
       },
     });
 
@@ -51,7 +55,7 @@ async function update(image, item) {
       name: item.nome,
       type: item.tipo,
       material: item.material,
-      ambientes: item.ambientes,
+      ambientes: serializeAmbientes(item.ambientes),
     },
   });
 

--- a/backend/src/utils/ambientes.js
+++ b/backend/src/utils/ambientes.js
@@ -21,4 +21,34 @@ function normalizeAmbientes(input) {
   return [];
 }
 
-module.exports = { normalizeAmbientes };
+function serializeAmbientes(values) {
+  const list = normalizeAmbientes(values);
+  return JSON.stringify(list);
+}
+
+function parseStoredAmbientes(value) {
+  if (Array.isArray(value)) {
+    return value;
+  }
+
+  if (typeof value !== "string") {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(value);
+    if (Array.isArray(parsed)) {
+      return parsed;
+    }
+  } catch (error) {
+    // Ignore JSON parse errors and fallback to normalization below.
+  }
+
+  return normalizeAmbientes(value);
+}
+
+module.exports = {
+  normalizeAmbientes,
+  serializeAmbientes,
+  parseStoredAmbientes,
+};


### PR DESCRIPTION
## Summary
- change the Prisma schema to store catalog `ambientes` as serialized text compatible with SQLite
- add helpers to normalize, serialize and deserialize `ambientes` values
- update the repository and seed routines to serialize before persisting and parse when reading

## Testing
- npm test *(fails: missing @prisma/client runtime in the offline environment)*


------
https://chatgpt.com/codex/tasks/task_e_6908f25bcb70832f8e8a2836ac79450f