### PR TITLE
Fix API base URL detection for local development

### DIFF
--- a/scripts/app-api.js
+++ b/scripts/app-api.js
@@ -7,8 +7,20 @@
       return configured.replace(/\/$/, "");
     }
 
-    if (window.location.origin && window.location.origin !== "null") {
-      return `${window.location.origin.replace(/\/$/, "")}/api`;
+    if (window.location && window.location.origin && window.location.origin !== "null") {
+      const origin = window.location.origin.replace(/\/$/, "");
+      const hostname = window.location.hostname;
+      const port = window.location.port;
+
+      const isLocalHost = ["localhost", "127.0.0.1", "[::1]"].includes(hostname);
+
+      if (!isLocalHost) {
+        return `${origin}/api`;
+      }
+
+      if (!port || port === "3000") {
+        return `${origin}/api`;
+      }
     }
 
     return "http://localhost:3000/api";


### PR DESCRIPTION
## Summary
- adjust the API base URL resolver to detect local dev servers running on different ports
- keep production deployments using the current same-origin API path while defaulting to localhost:3000 for local testing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6908ff60c384832f9cc8d86ba9e588b6