### PR TITLE
Ensure default admin accounts exist at startup

### DIFF
--- a/backend/prisma/seed.js
+++ b/backend/prisma/seed.js
@@ -5,8 +5,7 @@ const {
   normalizeAmbientes,
   serializeAmbientes,
 } = require("../src/utils/ambientes");
-const bcrypt = require("../src/lib/bcrypt");
-const userRepository = require("../src/repositories/user-repository");
+const { syncDefaultUsers } = require("../src/services/default-user-service");
 
 async function seedCatalog() {
   const catalogPath = path.join(__dirname, "..", "..", "assets", "catalogo.json");
@@ -45,28 +44,7 @@ async function seedCatalog() {
 }
 
 async function seedUsers() {
-  const seeds = [
-    {
-      username: "master",
-      password: "master",
-      role: "master",
-    },
-    {
-      username: "user",
-      password: "user",
-      role: "user",
-    },
-  ];
-
-  for (const seed of seeds) {
-    const passwordHash = await bcrypt.hash(seed.password);
-    await userRepository.upsertUser({
-      username: seed.username,
-      passwordHash,
-      role: seed.role,
-    });
-  }
-
+  await syncDefaultUsers();
   console.log("✅ Usuários administrativos sincronizados.");
 }
 

--- a/backend/src/config/default-users.js
+++ b/backend/src/config/default-users.js
@@ -1,0 +1,14 @@
+const defaultUsers = [
+  {
+    username: "master",
+    password: "master",
+    role: "master",
+  },
+  {
+    username: "user",
+    password: "user",
+    role: "user",
+  },
+];
+
+module.exports = { defaultUsers };

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -2,9 +2,11 @@ require("./config/register-alias");
 const { createApp } = require("@/app");
 const { env } = require("@/config/env");
 const { prisma } = require("@/lib/prisma-client");
+const { syncDefaultUsers } = require("@/services/default-user-service");
 
 async function bootstrap() {
   await prisma.$connect();
+  await syncDefaultUsers();
 
   const app = createApp();
   const server = app.listen(env.port, () => {

--- a/backend/src/services/default-user-service.js
+++ b/backend/src/services/default-user-service.js
@@ -1,0 +1,42 @@
+require("../config/register-alias");
+const bcrypt = require("@/lib/bcrypt");
+const userRepository = require("@/repositories/user-repository");
+const { defaultUsers: defaultUserSeeds } = require("@/config/default-users");
+
+async function syncDefaultUsers(users = defaultUserSeeds) {
+  for (const user of users) {
+    const existing = await userRepository.findByUsername(user.username);
+
+    if (!existing) {
+      const passwordHash = await bcrypt.hash(user.password);
+      await userRepository.upsertUser({
+        username: user.username,
+        passwordHash,
+        role: user.role,
+      });
+      continue;
+    }
+
+    const roleChanged = existing.role !== user.role;
+    const passwordChanged = !(await bcrypt.compare(
+      user.password,
+      existing.passwordHash
+    ));
+
+    if (!roleChanged && !passwordChanged) {
+      continue;
+    }
+
+    const passwordHash = passwordChanged
+      ? await bcrypt.hash(user.password)
+      : existing.passwordHash;
+
+    await userRepository.upsertUser({
+      username: user.username,
+      passwordHash,
+      role: user.role,
+    });
+  }
+}
+
+module.exports = { syncDefaultUsers };

--- a/backend/tests/default-user-service.test.js
+++ b/backend/tests/default-user-service.test.js
@@ -1,0 +1,65 @@
+require("../src/config/register-alias");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const { execSync } = require("child_process");
+const assert = require("node:assert/strict");
+const { describe, before, after, afterEach, test } = require("node:test");
+
+const databaseFile = path.join(os.tmpdir(), "default-user-service-test.sqlite");
+process.env.DATABASE_URL = `file:${databaseFile.replace(/\\/g, "/")}`;
+
+const { syncDefaultUsers } = require("@/services/default-user-service");
+const { defaultUsers } = require("@/config/default-users");
+const userRepository = require("@/repositories/user-repository");
+const bcrypt = require("@/lib/bcrypt");
+const { prisma } = require("@/lib/prisma-client");
+
+describe("default-user-service", () => {
+  before(async () => {
+    if (fs.existsSync(databaseFile)) {
+      fs.unlinkSync(databaseFile);
+    }
+
+    execSync("npx prisma migrate deploy", {
+      cwd: path.join(__dirname, ".."),
+      stdio: "inherit",
+    });
+  });
+
+  afterEach(async () => {
+    await prisma.user.deleteMany();
+  });
+
+  after(async () => {
+    await prisma.$disconnect();
+
+    if (fs.existsSync(databaseFile)) {
+      fs.unlinkSync(databaseFile);
+    }
+  });
+
+  test("creates default users when they do not exist", async () => {
+    await syncDefaultUsers(defaultUsers);
+
+    for (const seed of defaultUsers) {
+      const user = await userRepository.findByUsername(seed.username);
+      assert.ok(user, `User ${seed.username} should exist`);
+      assert.equal(user.role, seed.role);
+      assert.equal(
+        await bcrypt.compare(seed.password, user.passwordHash),
+        true
+      );
+    }
+  });
+
+  test("does not rehash passwords when no changes are needed", async () => {
+    await syncDefaultUsers(defaultUsers);
+    const before = await userRepository.findByUsername(defaultUsers[0].username);
+
+    await syncDefaultUsers(defaultUsers);
+    const after = await userRepository.findByUsername(defaultUsers[0].username);
+
+    assert.equal(before.passwordHash, after.passwordHash);
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared default user configuration and synchronization service
- sync administrative accounts during server bootstrap and reuse it in the seed script
- cover the new default user synchronization logic with automated tests

## Testing
- npm test *(fails: missing @prisma/client runtime modules in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_690906f897b8832fb6615691e031c70b