### PR TITLE
Add .env.example for Google Drive and validate Drive env vars

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,18 @@
+# Ambiente
+NODE_ENV=development
+PORT=3000
+
+# Google Drive (pasta raiz do site)
+DRIVE_FOLDER_ID=1c4fn51AmuMGrHoMZQRbQhLR5ZA2Z3n1h
+
+# Cole o JSON da service account em uma única linha.
+# Exemplo (NÃO use este valor):
+# GOOGLE_SERVICE_ACCOUNT_JSON={"type":"service_account","project_id":"..."}
+GOOGLE_SERVICE_ACCOUNT_JSON=
+
+# ---
+# Produção (exemplo):
+# NODE_ENV=production
+# PORT=3000
+# DRIVE_FOLDER_ID=1c4fn51AmuMGrHoMZQRbQhLR5ZA2Z3n1h
+# GOOGLE_SERVICE_ACCOUNT_JSON={"type":"service_account","project_id":"..."}


### PR DESCRIPTION
### Motivation
- Habilitar o uso do Google Drive para armazenamento de arquivos tanto em `development` quanto em `production` sem depender de arquivos locais em produção.
- Fornecer um `.env` de exemplo com `DRIVE_FOLDER_ID` e `GOOGLE_SERVICE_ACCOUNT_JSON` para o usuário preencher rapidamente.
- Fazer validações em tempo de inicialização para falhar cedo quando a configuração de Drive estiver incompleta em produção.

### Description
- Adiciona `backend/.env.example` com `NODE_ENV`, `PORT`, `DRIVE_FOLDER_ID` (já preenchido com o ID fornecido) e `GOOGLE_SERVICE_ACCOUNT_JSON` como placeholder para colar o JSON da service account.
- Substitui o uso de `GOOGLE_DRIVE_SITE_FOLDER_ID` por `DRIVE_FOLDER_ID` e adiciona validação que lança erro se `DRIVE_FOLDER_ID` não estiver definido.
- Passa a aceitar `GOOGLE_SERVICE_ACCOUNT_JSON` quando presente e a utilizá-lo para autenticar a `GoogleAuth`, mantendo fallback para `keyFile` apenas em `development` e lançando erro se faltar em `production`.
- Atualiza as queries e criação de pastas no Drive para usar `DRIVE_FOLDER_ID` ao buscar/criar `blocos` e ao localizar `blocosDB.json`.

### Testing
- Nenhum teste automatizado foi executado para estas alterações de configuração.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b5c22bc9c832faaf8edc77d99a286)